### PR TITLE
added drbd-adapter images for hwameistor

### DIFF
--- a/mirror.txt
+++ b/mirror.txt
@@ -359,7 +359,13 @@ ghcr.io/fluxcd/notification-controller
 ghcr.io/fluxcd/source-controller
 ghcr.io/hwameistor/admission
 ghcr.io/hwameistor/drbd-reactor
+ghcr.io/hwameistor/drbd9-bionic
+ghcr.io/hwameistor/drbd9-compiler-centos7
+ghcr.io/hwameistor/drbd9-compiler-centos8
+ghcr.io/hwameistor/drbd9-focal
+ghcr.io/hwameistor/drbd9-jammy
 ghcr.io/hwameistor/drbd9-rhel7
+ghcr.io/hwameistor/drbd9-rhel8
 ghcr.io/hwameistor/drbd9-shipper
 ghcr.io/hwameistor/local-disk-manager
 ghcr.io/hwameistor/local-storage
@@ -543,13 +549,3 @@ registry.k8s.io/sig-storage/livenessprobe
 registry.k8s.io/sig-storage/local-volume-provisioner
 registry.k8s.io/sig-storage/snapshot-controller
 rocks.canonical.com/mariadb/server
-ghcr.io/hwameistor/drbd9-bionic
-ghcr.io/hwameistor/drbd9-compiler-centos7
-ghcr.io/hwameistor/drbd9-compiler-centos8
-ghcr.io/hwameistor/drbd9-focal
-ghcr.io/hwameistor/drbd9-jammy
-ghcr.io/hwameistor/drbd9-rhel7
-ghcr.io/hwameistor/drbd9-rhel8
-ghcr.io/hwameistor/drbd9-shipper
-ghcr.io/hwameistor/drbd-reactor
-

--- a/mirror.txt
+++ b/mirror.txt
@@ -360,8 +360,6 @@ ghcr.io/fluxcd/source-controller
 ghcr.io/hwameistor/admission
 ghcr.io/hwameistor/drbd-reactor
 ghcr.io/hwameistor/drbd9-bionic
-ghcr.io/hwameistor/drbd9-compiler-centos7
-ghcr.io/hwameistor/drbd9-compiler-centos8
 ghcr.io/hwameistor/drbd9-focal
 ghcr.io/hwameistor/drbd9-jammy
 ghcr.io/hwameistor/drbd9-rhel7

--- a/mirror.txt
+++ b/mirror.txt
@@ -543,3 +543,13 @@ registry.k8s.io/sig-storage/livenessprobe
 registry.k8s.io/sig-storage/local-volume-provisioner
 registry.k8s.io/sig-storage/snapshot-controller
 rocks.canonical.com/mariadb/server
+ghcr.io/hwameistor/drbd9-bionic
+ghcr.io/hwameistor/drbd9-compiler-centos7
+ghcr.io/hwameistor/drbd9-compiler-centos8
+ghcr.io/hwameistor/drbd9-focal
+ghcr.io/hwameistor/drbd9-jammy
+ghcr.io/hwameistor/drbd9-rhel7
+ghcr.io/hwameistor/drbd9-rhel8
+ghcr.io/hwameistor/drbd9-shipper
+ghcr.io/hwameistor/drbd-reactor
+


### PR DESCRIPTION
Signed-off-by: alexzhc <alex.zheng@daocloud.io>

added drbd-adapter images for hwameistor:

```
ghcr.io/hwameistor/drbd9-bionic
ghcr.io/hwameistor/drbd9-compiler-centos7
ghcr.io/hwameistor/drbd9-compiler-centos8
ghcr.io/hwameistor/drbd9-focal
ghcr.io/hwameistor/drbd9-jammy
ghcr.io/hwameistor/drbd9-rhel7
ghcr.io/hwameistor/drbd9-rhel8
ghcr.io/hwameistor/drbd9-shipper
ghcr.io/hwameistor/drbd-reactor
```