### PR TITLE
add keycloak repository

### DIFF
--- a/mirror.txt
+++ b/mirror.txt
@@ -467,6 +467,7 @@ quay.io/k8scsi/csi-resizer
 quay.io/k8scsi/csi-snapshotter
 quay.io/k8scsi/livenessprobe
 quay.io/k8scsi/snapshot-controller
+quay.io/keycloak/keycloak
 quay.io/kiali/kiali
 quay.io/kiwigrid/k8s-sidecar
 quay.io/kubespray/kubespray


### PR DESCRIPTION
The keycloak image has been migrated to the new address：/quay.io/repository/keycloak/keycloak