### PR TITLE
add zalan.do for PG operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,28 @@ docker run -d -P m.daocloud.io/docker.io/library/nginx
 
 [mirror.txt](mirror.txt)
 
-如果想要新增, 提 PR 修改即可。例如 [PR#1](https://github.com/DaoCloud/public-image-mirror/pull/1/)
+如果想要新增, 提 PR 修改即可。例如 [PR#1](https://github.com/DaoCloud/public-image-mirror/pull/1/)， 并请在 PR 提交前排序： `./hack/fmt.sh mirror.txt`
 
 ## 使用方法
 
-*增加前缀*。比如：
+## 添加一级域名
 
+**增加前缀** (推荐方式)。比如：
+```
 k8s.gcr.io/coredns/coredns => m.daocloud.io/k8s.gcr.io/coredns/coredns
+```
 
 或者 支持的镜像仓库 的 *前缀替换* 就可以使用。比如：
 
+```
 k8s.gcr.io/coredns/coredns => k8s-gcr.m.daocloud.io/coredns/coredns
+```
 
 ## 支持前缀替换的 Registry
 
 [domain.txt](domain.txt)
 
-如果想要新增, 提 PR 修改即可。例如 [PR#28](https://github.com/DaoCloud/public-image-mirror/pull/28)
+如果想要新增, 提 PR 修改即可。例如 [PR#28](https://github.com/DaoCloud/public-image-mirror/pull/28),  并请在 PR 提交前排序：`./hack/fmt.sh domain.txt`
 
 ### 前缀替换的 Registry 的规则
 

--- a/domain.txt
+++ b/domain.txt
@@ -9,5 +9,5 @@ nvcr.io/=m.daocloud.io/nvcr.io/
 quay.io/=m.daocloud.io/quay.io/
 registry.jujucharms.com/=m.daocloud.io/registry.jujucharms.com/
 registry.k8s.io/=m.daocloud.io/registry.k8s.io/
-registry.opensource.zalan.do=m.daocloud.io/registry.opensource.zalan.do/
+registry.opensource.zalan.do/=m.daocloud.io/registry.opensource.zalan.do/
 rocks.canonical.com/=m.daocloud.io/rocks.canonical.com/

--- a/domain.txt
+++ b/domain.txt
@@ -9,4 +9,5 @@ nvcr.io/=m.daocloud.io/nvcr.io/
 quay.io/=m.daocloud.io/quay.io/
 registry.jujucharms.com/=m.daocloud.io/registry.jujucharms.com/
 registry.k8s.io/=m.daocloud.io/registry.k8s.io/
+registry.opensource.zalan.do=m.daocloud.io/registry.opensource.zalan.do/
 rocks.canonical.com/=m.daocloud.io/rocks.canonical.com/

--- a/mirror.txt
+++ b/mirror.txt
@@ -574,3 +574,7 @@ registry.k8s.io/sig-storage/livenessprobe
 registry.k8s.io/sig-storage/local-volume-provisioner
 registry.k8s.io/sig-storage/nfs-subdir-external-provisioner
 registry.k8s.io/sig-storage/snapshot-controller
+registry.opensource.zalan.do/acid/logical-backup
+registry.opensource.zalan.do/acid/pgbouncer
+registry.opensource.zalan.do/acid/postgres-operator
+registry.opensource.zalan.do/acid/spilo-14


### PR DESCRIPTION
我有一点搞不清楚
`zalan.m.daocloud.io` 这个域名在哪里配置的？

这些配置文件里都没有。