### PR TITLE
Use jenkins/inbound-agent instead jnlp-slave

### DIFF
--- a/mirror.txt
+++ b/mirror.txt
@@ -151,7 +151,7 @@ docker.io/jaegertracing/jaeger-query
 docker.io/jaegertracing/spark-dependencies
 docker.io/java
 docker.io/jboss/keycloak
-docker.io/jenkins/jnlp-slave
+docker.io/jenkins/inbound-agent
 docker.io/jertel/elastalert2
 docker.io/jimmidyson/configmap-reload
 docker.io/joosthofman/wget


### PR DESCRIPTION
jnlp-slave is deprecated, use inbound-agent instead

https://hub.docker.com/r/jenkins/inbound-agent