### PR TITLE
chore(ci): migrate to `checkout@v4`

### DIFF
--- a/.github/workflows/check-images.yml
+++ b/.github/workflows/check-images.yml
@@ -9,7 +9,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check Image
         run: |
           ./hack/verify-image.sh mirror.txt

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'DaoCloud/public-image-mirror'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Start Proxy
         env:
           only_proxy: "m.daocloud.io"
@@ -37,7 +37,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BADGE_PREFIX: "git://${{ github.repository }}/gh-pages"
-          QUICKLY: "true"  
+          QUICKLY: "true"
         run: |
           wget https://github.com/wzshiming/putingh/releases/download/v0.6.3/putingh_linux_amd64 -O /usr/local/bin/putingh && chmod +x /usr/local/bin/putingh
           ./hack/badge.sh

--- a/.github/workflows/manual-deep-sync.yml
+++ b/.github/workflows/manual-deep-sync.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Start Proxy
         env:
           only_proxy: "m.daocloud.io"

--- a/.github/workflows/manual-sync.yml
+++ b/.github/workflows/manual-sync.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Start Proxy
         env:
           only_proxy: "m.daocloud.io"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Start Proxy
         env:
           only_proxy: "m.daocloud.io"

--- a/.github/workflows/target-image-sync.yml
+++ b/.github/workflows/target-image-sync.yml
@@ -16,7 +16,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Check Issue
       env:
         MESSAGE: "${{ github.event.issue.body }}"

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -18,7 +18,7 @@ jobs:
   verify-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Commit PR
         run: |
           git config --global user.name "bot"


### PR DESCRIPTION
Currently `checkout@v4` uses the version 12 for `nodejs` and will prompt deprecation warnings each time the GitHub Actions runs. Should migrate to `checkout@v4`.

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

There are no special use cases, so it is fully compatible to migrate from `checkout@v2` to `checkout@v4` without any problems.

Actions that produce warning messages: https://github.com/DaoCloud/public-image-mirror/actions/runs/7042397850