### PR TITLE
add proton to mirror

### DIFF
--- a/mirror.txt
+++ b/mirror.txt
@@ -303,6 +303,7 @@ ghcr.io/spiffe/spire-agent
 ghcr.io/spiffe/spire-server
 ghcr.io/sumologic/tailing-sidecar
 ghcr.io/sumologic/tailing-sidecar-operator
+ghcr.io/timeplus-io/proton
 quay.io/argoproj/argo-rollouts
 quay.io/argoproj/argocd
 quay.io/argoproj/argocli


### PR DESCRIPTION
Proton https://github.com/timeplus-io/proton is a streaming proccessing tool, the default image is published to `ghcr.io/timeplus-io/proton` which is very slow to access in china, thanks DaoCloud, the mirror will help china community to access the image easier.