### PR TITLE
Add ghcr.io/cirruslabs/macos-sonoma-xcode

### DIFF
--- a/mirror.txt
+++ b/mirror.txt
@@ -322,6 +322,7 @@ ghcr.io/aquasecurity/trivy-java-db
 ghcr.io/chaos-mesh/chaos-daemon
 ghcr.io/chaos-mesh/chaos-dashboard
 ghcr.io/chaos-mesh/chaos-mesh
+ghcr.io/cirruslabs/macos-sonoma-xcode
 ghcr.io/daocloud/dao-2048
 ghcr.io/daocloud/netmaterial
 ghcr.io/dexidp/dex


### PR DESCRIPTION
This image is used to store macOS VM for tart executors which is widely used in CI for gitlab. See https://github.com/cirruslabs/tart/ for more information.

Related Issue: #2464