### PR TITLE
Add Jellyfin and LinuxServer Repositories

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -30,6 +30,7 @@ docker.io/grafana/**
 docker.io/istio/**
 docker.io/jaegertracing/**
 docker.io/jboss/**
+docker.io/jellyfin/**
 docker.io/jenkins/**
 docker.io/jimmidyson/**
 docker.io/karmada/**
@@ -42,6 +43,7 @@ docker.io/kubeflownotebookswg/**
 docker.io/kuberhealthy/**
 docker.io/kubernetesui/**
 docker.io/library/**
+docker.io/linuxserver/**
 docker.io/longhornio/**
 docker.io/louislam/**
 docker.io/minio/**
@@ -58,7 +60,6 @@ docker.io/openkruise/**
 docker.io/openzipkin/**
 docker.io/osixia/**
 docker.io/otel/**
-docker.io/linuxserver/**
 docker.io/percona/**
 docker.io/phpmyadmin/**
 docker.io/portainer/**
@@ -78,7 +79,6 @@ docker.io/velero/**
 docker.io/vesoft/**
 docker.io/victoriametrics/**
 docker.io/weaveworks/**
-docker.io/jellyfin/**
 gcr.io/**
 ghcr.io/aquasecurity/**
 ghcr.io/chaos-mesh/**

--- a/allows.txt
+++ b/allows.txt
@@ -77,6 +77,7 @@ docker.io/velero/**
 docker.io/vesoft/**
 docker.io/victoriametrics/**
 docker.io/weaveworks/**
+docker.io/jellyfin/**
 gcr.io/**
 ghcr.io/aquasecurity/**
 ghcr.io/chaos-mesh/**

--- a/allows.txt
+++ b/allows.txt
@@ -58,6 +58,7 @@ docker.io/openkruise/**
 docker.io/openzipkin/**
 docker.io/osixia/**
 docker.io/otel/**
+docker.io/linuxserver/**
 docker.io/percona/**
 docker.io/phpmyadmin/**
 docker.io/portainer/**

--- a/mirror.txt
+++ b/mirror.txt
@@ -71,8 +71,6 @@ docker.io/fluent/fluentd
 docker.io/fortio/fortio
 docker.io/foxdalas/kafka-manager
 docker.io/frrouting/frr
-docker.io/jellyfin/jellyfin
-docker.io/linuxserver/jellyfin
 docker.io/goharbor/chartmuseum-photon
 docker.io/goharbor/harbor-core
 docker.io/goharbor/harbor-db
@@ -103,6 +101,7 @@ docker.io/jaegertracing/jaeger-es-index-cleaner
 docker.io/jaegertracing/jaeger-operator
 docker.io/jaegertracing/jaeger-query
 docker.io/jboss/keycloak
+docker.io/jellyfin/jellyfin
 docker.io/jenkins/inbound-agent
 docker.io/jimmidyson/configmap-reload
 docker.io/karmada/karmada-aggregated-apiserver
@@ -212,6 +211,7 @@ docker.io/library/varnish
 docker.io/library/wordpress
 docker.io/library/yourls
 docker.io/library/zookeeper
+docker.io/linuxserver/jellyfin
 docker.io/longhornio/longhorn-engine
 docker.io/longhornio/longhorn-manager
 docker.io/longhornio/longhorn-ui

--- a/mirror.txt
+++ b/mirror.txt
@@ -72,6 +72,7 @@ docker.io/fortio/fortio
 docker.io/foxdalas/kafka-manager
 docker.io/frrouting/frr
 docker.io/jellyfin/jellyfin
+docker.io/linuxserver/jellyfin
 docker.io/goharbor/chartmuseum-photon
 docker.io/goharbor/harbor-core
 docker.io/goharbor/harbor-db

--- a/mirror.txt
+++ b/mirror.txt
@@ -71,6 +71,7 @@ docker.io/fluent/fluentd
 docker.io/fortio/fortio
 docker.io/foxdalas/kafka-manager
 docker.io/frrouting/frr
+docker.io/jellyfin/jellyfin
 docker.io/goharbor/chartmuseum-photon
 docker.io/goharbor/harbor-core
 docker.io/goharbor/harbor-db


### PR DESCRIPTION
Added repositories for Jellyfin and LinuxServer, and included a Jellyfin image to allow NAS users to conveniently pull the image on their local machines.