### PR TITLE
白名单中增加了GOCD镜像

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -36,6 +36,7 @@ docker.io/fortio/**
 docker.io/foxdalas/**
 docker.io/frrouting/**
 docker.io/gitlab/**
+docker.io/gocd/gocd-server
 docker.io/goharbor/**
 docker.io/grafana/**
 docker.io/gztime/gzctf

--- a/allows.txt
+++ b/allows.txt
@@ -339,3 +339,4 @@ registry.jujucharms.com/**
 registry.k8s.io/**
 registry.opensource.zalan.do/**
 rocks.canonical.com/**
+docker.io/gocd/gocd-server

--- a/allows.txt
+++ b/allows.txt
@@ -339,4 +339,3 @@ registry.jujucharms.com/**
 registry.k8s.io/**
 registry.opensource.zalan.do/**
 rocks.canonical.com/**
-docker.io/gocd/gocd-server


### PR DESCRIPTION
官网 https://www.gocd.org/
源码地址 https://github.com/gocd/gocd
docker镜像源码 https://github.com/gocd/docker-gocd-server