### PR TITLE
add docker/dockerfile

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -25,6 +25,7 @@ docker.io/csiplugin/**
 docker.io/curlimages/**
 docker.io/deepflowce/**
 docker.io/directus/**
+docker.io/docker/dockerfile
 docker.io/dpage/**
 docker.io/elastic/**
 docker.io/emby/**

--- a/allows.txt
+++ b/allows.txt
@@ -25,7 +25,7 @@ docker.io/csiplugin/**
 docker.io/curlimages/**
 docker.io/deepflowce/**
 docker.io/directus/**
-docker.io/docker/dockerfile
+docker.io/docker/**
 docker.io/dpage/**
 docker.io/elastic/**
 docker.io/emby/**

--- a/mirror.txt
+++ b/mirror.txt
@@ -54,6 +54,7 @@ docker.io/deepflowce/deepflowio-init-grafana
 docker.io/deepflowce/deepflowio-init-grafana-ds-dh
 docker.io/deepflowce/grafana
 docker.io/deepflowce/mysql
+docker.io/docker/dockerfile
 docker.io/dpage/pgadmin4
 docker.io/elastic/filebeat
 docker.io/emby/embyserver


### PR DESCRIPTION
使用 Dockerfile 高级特性时会使用

使用方法：

```
# syntax=docker.io/docker/dockerfile:1
FROM ubuntu
```

docker.io/docker/** 都是 docker 官方的镜像，应该还是比较安全的，全部 allow 了。

源码和构建流水线：
https://github.com/moby/buildkit/blob/master/.github/workflows/frontend.yml

