### PR TITLE
Add two images used by HTNN developers

### DIFF
--- a/mirror.txt
+++ b/mirror.txt
@@ -68,6 +68,7 @@ docker.io/falcosecurity/falco-driver-loader
 docker.io/falcosecurity/falco-exporter
 docker.io/falcosecurity/falco-no-driver
 docker.io/falcosecurity/falcosidekick
+docker.io/floryn90/hugo
 docker.io/fluent/fluent-bit
 docker.io/fluent/fluentd
 docker.io/fortio/fortio
@@ -372,6 +373,7 @@ ghcr.io/megacloudcontainer/kubeaudit
 ghcr.io/mellanox/k8s-rdma-shared-dev-plugin
 ghcr.io/mellanox/network-operator-init-container
 ghcr.io/mosn/htnn-controller
+ghcr.io/mosn/htnn-dev-tools
 ghcr.io/mosn/htnn-proxy
 ghcr.io/open-telemetry/demo
 ghcr.io/open-telemetry/opentelemetry-go-instrumentation/autoinstrumentation-go


### PR DESCRIPTION
docker.io/floryn90/hugo 用于构造 HTNN 的网站，它的主页是 https://hub.docker.com/r/floryn90/hugo。

ghcr.io/mosn/htnn-dev-tools 镜像用于打包 HTNN 的开发工具，它的 Dockerfile 位于 https://github.com/mosn/htnn/blob/main/tools/Dockerfile.dev。