### PR TITLE
添加 hugomods/hugo 到白名单

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -67,6 +67,7 @@ docker.io/halohub/halo
 docker.io/hectorqin/reader
 docker.io/homeassistant/**
 docker.io/hoppscotch/hoppscotch
+docker.io/hugomods/hugo
 docker.io/hyperf/hyperf
 docker.io/hyperledger/**
 docker.io/infmonkeys/**


### PR DESCRIPTION
Hugo (静态网站生成器) 的另一个镜像，`klakegg/hugo` 已经停止更新很久了。