### PR TITLE
add Flutter docker image into whitelist

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -351,6 +351,7 @@ gcr.io/**
 ghcr.io/aquasecurity/**
 ghcr.io/benc-uk/kubeview
 ghcr.io/chaos-mesh/**
+ghcr.io/cirruslabs/flutter
 ghcr.io/cloudtty/cloudshell
 ghcr.io/coder/**
 ghcr.io/cowboysysop/pytest


### PR DESCRIPTION
ERROR: Job failed: failed to pull image "ghcr.m.daocloud.io/cirruslabs/flutter:3.22.2" with specified policies [always]: Error response from daemon: pull access denied for ghcr.m.daocloud.io/cirruslabs/flutter, repository does not exist or may require 'docker login': denied: 🚫 这镜像不在白名单. this image is not in the allowlist. 📦 https://github.com/DaoCloud/public-image-mirror/issues/2328 🔗 (manager.go:250:0s)