### PR TITLE
allow docker.io/flowiseai/flowise

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -52,6 +52,7 @@ docker.io/filebrowser/filebrowser
 docker.io/fireflyiii/**
 docker.io/flannel/**
 docker.io/floryn90/hugo
+docker.io/flowiseai/flowise
 docker.io/fluent/**
 docker.io/fortio/**
 docker.io/foxdalas/**


### PR DESCRIPTION
白名单级别
只需要这一个镜像 

项目源码地址 或 组织地址
https://github.com/FlowiseAI/Flowise

官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)
https://github.com/FlowiseAI/Flowise/tree/main/docker

镜像仓库地址
https://hub.docker.com/r/flowiseai/flowise