### PR TITLE
Update allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -120,8 +120,10 @@ docker.io/kindest/*
 docker.io/kiwigrid/*
 docker.io/klakegg/hugo
 docker.io/koalaman/shellcheck
+docker.io/kserve/*
 docker.io/kubeedge/*
 docker.io/kubeflow/*
+docker.io/kubeflowkatib/*
 docker.io/kubeflownotebookswg/*
 docker.io/kubeovn/kube-ovn
 docker.io/kuberhealthy/*
@@ -455,6 +457,7 @@ marketplace.azurecr.io/bitnami/**
 mcr.microsoft.com/**
 nvcr.io/**
 ollama.ai/**
+quay.io/aipipeline/*
 quay.io/argoproj/*
 quay.io/brancz/*
 quay.io/calico/*


### PR DESCRIPTION
添加了人工智能MLOPS项目kubeflow中用到的部分镜像仓库组织。

官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)：
项目根目录：https://github.com/kubeflow
k8s部署配置文件项目：https://github.com/kubeflow/manifests
包含镜像的文件举例：https://github.com/kubeflow/manifests/blob/v1.8.1/apps/admission-webhook/upstream/base/deployment.yaml