### PR TITLE
feat: Add docker.io/fatedier/frps to the whitelist

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -67,6 +67,7 @@ docker.io/ensemblorg/ensembl-vep
 docker.io/envoyproxy/*
 docker.io/f5networks/*
 docker.io/falcosecurity/*
+docker.io/fatedier/frps
 docker.io/filebrowser/filebrowser
 docker.io/fireflyiii/*
 docker.io/flannel/*


### PR DESCRIPTION
I want added [frp](https://github.com/fatedier/frp) reverse proxy tool

source code: [frp](https://github.com/fatedier/frp) `CC https://github.com/fatedier/frp`