### PR TITLE
add docker.io/texlive/texlive to allows

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -404,6 +404,7 @@ docker.io/talebook/talebook
 docker.io/tdengine/*
 docker.io/tensorchord/pgvecto-rs
 docker.io/tensorflow/*
+docker.io/texlive/texlive
 docker.io/thanosio/*
 docker.io/thingsboard/tb-postgres
 docker.io/tiangolo/*


### PR DESCRIPTION
**白名单级别**
仅一个镜像

**镜像仓库地址**
https://hub.docker.com/r/texlive/texlive

**这是镜像仓库官方认证过的么?**
否。这是 texlive 官方的创建的。项目地址：http://tug.org/texlive/

**官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)**
此项目的源代码及[docker 镜像定义](https://gitlab.com/islandoftex/images/texlive/-/blob/master/Dockerfile)