### PR TITLE
添加streamnative到白名单

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -21,7 +21,6 @@ docker.io/andywuwu/coze2openai
 docker.io/ankane/pgvector
 docker.io/apache/*
 docker.io/apachepulsar/*
-docker.io/streamnative/*
 docker.io/apitable/*
 docker.io/apolloconfig/*
 docker.io/appsmith/appsmith-ce
@@ -436,6 +435,7 @@ docker.io/sonobuoy/*
 docker.io/soulter/astrbot
 docker.io/squidfunk/*
 docker.io/starrocks/*
+docker.io/streamnative/*
 docker.io/superng6/qbittorrentee
 docker.io/swaggerapi/*
 docker.io/syncthing/syncthing

--- a/allows.txt
+++ b/allows.txt
@@ -21,6 +21,7 @@ docker.io/andywuwu/coze2openai
 docker.io/ankane/pgvector
 docker.io/apache/*
 docker.io/apachepulsar/*
+docker.io/streamnative/*
 docker.io/apitable/*
 docker.io/apolloconfig/*
 docker.io/appsmith/appsmith-ce


### PR DESCRIPTION
白名单级别
需要这个组织下的所有镜像 (如 docker.io/streamnative/*)

镜像仓库地址
https://hub.docker.com/r/streamnative/...

这是镜像仓库官方认证过的么?
不是(请补充下面的信息，乱填将关闭申请)

项目源码地址 或 组织地址
https://github.com/streamnative

官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)
https://github.com/streamnative

补充说明
StreamNative
Cloud-Native Kafka compatible data streaming platform powered by the Ursa engine