### PR TITLE
chore: add ghcr.io/huggingface/text-generation-inference into allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -522,6 +522,7 @@ ghcr.io/gethomepage/homepage
 ghcr.io/goauthentik/**
 ghcr.io/helm/**
 ghcr.io/home-assistant/**
+ghcr.io/huggingface/text-generation-inference
 ghcr.io/hwameistor/**
 ghcr.io/immich-app/**
 ghcr.io/jimmidyson/configmap-reload


### PR DESCRIPTION
- 白名单级别: 只需要这一个镜像
-
- 镜像仓库地址: ghcr.io/huggingface/text-generation-inference

- 这是镜像仓库官方认证过的么: 是