### PR TITLE
Update allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -399,6 +399,7 @@ docker.io/osixia/*
 docker.io/osrf/*
 docker.io/otel/*
 docker.io/outlinewiki/outline
+docker.io/pandoc/*
 docker.io/percona/*
 docker.io/pgautoupgrade/pgautoupgrade
 docker.io/pgvector/pgvector


### PR DESCRIPTION
pandoc 镜像，这是一个老牌的文档转换工具

hub 地址：https://hub.docker.com/u/pandoc
网站官网：https://pandoc.org/