### PR TITLE
Update allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -143,6 +143,7 @@ docker.io/halohub/halo
 docker.io/harness/*
 docker.io/haroldli/xiaoya-tvbox
 docker.io/hashicorp/consul
+docker.io/headscale/headscale
 docker.io/heartexlabs/label-studio
 docker.io/hectorqin/reader
 docker.io/hengyunabc/arthas


### PR DESCRIPTION
add docker.io/headscale/headscale


https://github.com/juanfont/headscale

An open source, self-hosted implementation of the Tailscale control server.
