### PR TITLE
Update allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -506,7 +506,7 @@ docker.io/qdrant/*
 docker.io/qemux/qemu-docker
 docker.io/qmcgaw/ddns-updater
 docker.io/quickwit/*
-docker.io/radondb/percona
+docker.io/radondb/*
 docker.io/ramonvc/freegpt-webui
 docker.io/rancher/*
 docker.io/rayproject/*


### PR DESCRIPTION
更新百名单：docker.io/radondb/*

需要这个组织下所有镜像 (如 docker.io/library/*)

镜像仓库地址
https://hub.docker.com/u/radondb

这是 镜像仓库 认证可信的 验证过的发布者(Verified Publisher)或者赞助的项目(Sponsored OSS) 么?
不是 - 请补充下面的信息

项目源码地址 或 组织地址
https://github.com/FudanSELab/train-ticket

官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)
开源项目需要这个组织下的镜像，之前只加了一个，需要在加，麻烦在帮忙添加一下，谢谢
https://github.com/FudanSELab/train-ticket/blob/master/deployment/kubernetes-manifests/quickstart-k8s/charts/mysql/README.md?plain=1

![image](https://github.com/user-attachments/assets/ef279bce-b2d1-47cb-a239-cf9c57d1397f)
![image](https://github.com/user-attachments/assets/23474a26-c665-49f7-8d45-0b4f99aa0386)

