### PR TITLE
Update allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -628,7 +628,6 @@ docker.io/zilliz/*
 docker.io/zlijingtao/neurobfuscator
 docker.io/zlmediakit/zlmediakit
 docker.io/zmisgod/iptvchecker
-docker.io/zmisgod/iptvchecker
 docker.osgeo.org/**
 gcr.io/**
 ghcr.io/actions/**

--- a/allows.txt
+++ b/allows.txt
@@ -622,8 +622,8 @@ docker.io/zabbix/*
 docker.io/zadam/trilium
 docker.io/zerotier/*
 docker.io/zhaojun1998/zfile-pro
-docker.io/zhongyuanzhao000/docker_elastic_co_kibana_kibana-oss
 docker.io/zhayujie/chatgpt-on-wechat
+docker.io/zhongyuanzhao000/docker_elastic_co_kibana_kibana-oss
 docker.io/zilliz/*
 docker.io/zlijingtao/neurobfuscator
 docker.io/zlmediakit/zlmediakit

--- a/allows.txt
+++ b/allows.txt
@@ -622,10 +622,12 @@ docker.io/zabbix/*
 docker.io/zadam/trilium
 docker.io/zerotier/*
 docker.io/zhaojun1998/zfile-pro
+docker.io/zhongyuanzhao000/docker_elastic_co_kibana_kibana-oss
 docker.io/zhayujie/chatgpt-on-wechat
 docker.io/zilliz/*
 docker.io/zlijingtao/neurobfuscator
 docker.io/zlmediakit/zlmediakit
+docker.io/zmisgod/iptvchecker
 docker.io/zmisgod/iptvchecker
 docker.osgeo.org/**
 gcr.io/**


### PR DESCRIPTION
更新白名单：zhongyuanzhao000/docker_elastic_co_kibana_kibana-oss

需要这个组织下所有镜像 (如 docker.io/library/*)

镜像仓库地址
https://hub.docker.com/r/zhongyuanzhao000/docker_elastic_co_kibana_kibana-oss

这是 镜像仓库 认证可信的 验证过的发布者(Verified Publisher)或者赞助的项目(Sponsored OSS) 么?
不是 - 请补充下面的信息

项目源码地址 或 组织地址
https://github.com/FudanSELab/train-ticket

官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)
开源项目需要这个组织下的镜像，之前只加了一个，需要在加，麻烦在帮忙添加一下，谢谢
https://github.com/FudanSELab/train-ticket/blob/master/deployment/kubernetes-manifests/efk-deployment/kibana-deployment.yaml

<img width="1346" alt="image" src="https://github.com/user-attachments/assets/9255d677-1df8-419b-bdff-63fd0c82e29c">
