### PR TITLE
Update allows.txt (#38542)

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -628,6 +628,7 @@ docker.io/twinproduction/gatus
 docker.io/ubuntu/*
 docker.io/ultralytics/*
 docker.io/uozi/nginx-ui
+docker.io/uwang/115-strm
 docker.io/valkey/valkey
 docker.io/vaultwarden/server
 docker.io/vdsm/virtual-dsm


### PR DESCRIPTION
https://github.com/DaoCloud/public-image-mirror/issues/38542

allow docker.io/uwang/115-strm
