### PR TITLE
添加gaecfovdocker/pulsar-console到白名单

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -154,6 +154,7 @@ docker.io/frappe/*
 docker.io/frooodle/s-pdf
 docker.io/frrouting/*
 docker.io/funcman/115pc
+docker.io/gaecfovdocker/pulsar-console
 docker.io/geoservercloud/*
 docker.io/gerritcodereview/gerrit
 docker.io/getmeili/*


### PR DESCRIPTION
白名单级别
只需要这一个镜像 (如 docker.io/gaecfovdocker/pulsar-console)

镜像仓库地址
https://hub.docker.com/r/gaecfovdocker/pulsar-console

这是镜像仓库官方认证过的么?
不是(请补充下面的信息，乱填将关闭申请)

项目源码地址 或 组织地址
https://github.com/gaecfov/pulsar-console

官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)
https://github.com/gaecfov/pulsar-console

补充说明
pulsar-console
Pulsar Console 是基于 Pulsar Admin REST Api 构建的Pulsar UI控制台。