### PR TITLE
添加datastax到白名单

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -92,6 +92,7 @@ docker.io/dadoum/anisette-v3-server
 docker.io/danielqsj/kafka-exporter
 docker.io/daprio/*
 docker.io/darthsim/imgproxy
+docker.io/datastax/*
 docker.io/debezium/*
 docker.io/deepflowce/*
 docker.io/deluan/navidrome


### PR DESCRIPTION
白名单级别
需要这个组织下的所有镜像 (如 docker.io/datastax/*)

镜像仓库地址
https://hub.docker.com/r/datastax/...

这是镜像仓库官方认证过的么?
不是(请补充下面的信息，乱填将关闭申请)

项目源码地址 或 组织地址
https://github.com/datastax

官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)
https://github.com/datastax

补充说明
datastax
DataStax, is a registered trademark of DataStax, Inc.. Apache, Apache Cassandra, Cassandra, Apache Pulsar, and Pulsar are either registered trademarks or trademarks of the Apache Software Foundation.