### PR TITLE
添加cars10/elasticvue、appbaseio/dejavu到白名单

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -33,6 +33,7 @@ docker.io/apachepulsar/*
 docker.io/apicurio/*
 docker.io/apitable/*
 docker.io/apolloconfig/*
+docker.io/appbaseio/dejavu
 docker.io/approachingai/*
 docker.io/appsmith/appsmith-ce
 docker.io/appsmith/appsmith-ee
@@ -64,6 +65,7 @@ docker.io/bytelang/kplayer
 docker.io/calciumion/new-api
 docker.io/calico/*
 docker.io/camunda/zeebe
+docker.io/cars10/elasticvue
 docker.io/casbin/casdoor
 docker.io/certbot/*
 docker.io/chaosbladeio/chaosblade-box


### PR DESCRIPTION
白名单级别
只需要这一个镜像 (如 docker.io/cars10/elasticvue、appbaseio/dejavu)

镜像仓库地址
https://hub.docker.com/r/cars10/elasticvue
https://hub.docker.com/r/appbaseio/dejavu

这是镜像仓库官方认证过的么?
不是(请补充下面的信息，乱填将关闭申请)

项目源码地址 或 组织地址
https://github.com/cars10/elasticvue
https://github.com/appbaseio/dejavu

官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)
https://elasticvue.com/
https://github.com/appbaseio/dejavu

补充说明
cars10/elasticvue
Elasticsearch gui - for desktop & your browser
appbaseio/dejavu
A Web UI for Elasticsearch and OpenSearch: Import, browse and edit data with rich filters and query views, create reference search UIs.