### PR TITLE
Allow docker.io/kanidm/*

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -247,6 +247,7 @@ docker.io/jupyterhub/*
 docker.io/justsong/one-api
 docker.io/jxxghp/*
 docker.io/k8scloudprovider/*
+docker.io/kanidm/*
 docker.io/karmada/*
 docker.io/kasmweb/chrome
 docker.io/kasmweb/core-ubuntu-focal


### PR DESCRIPTION
Fixed #40551 