### PR TITLE
Update allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -523,6 +523,7 @@ docker.io/owncloud/server
 docker.io/p3terx/aria2-pro
 docker.io/paddlepaddle/paddle
 docker.io/pandoc/*
+docker.io/paketobuildpacks/*
 docker.io/percona/*
 docker.io/pgautoupgrade/pgautoupgrade
 docker.io/pgrouting/pgrouting

--- a/allows.txt
+++ b/allows.txt
@@ -522,8 +522,8 @@ docker.io/oven/bun
 docker.io/owncloud/server
 docker.io/p3terx/aria2-pro
 docker.io/paddlepaddle/paddle
-docker.io/pandoc/*
 docker.io/paketobuildpacks/*
+docker.io/pandoc/*
 docker.io/percona/*
 docker.io/pgautoupgrade/pgautoupgrade
 docker.io/pgrouting/pgrouting


### PR DESCRIPTION
This image is for the Spring Boot Maven plugin. That plugin allows the image to have multiple layers. When you build it for the first time and then change the codebase, it doesn’t need to rebuild all the layers—just the one you modified.