### PR TITLE
添加hivemq到白名单

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -219,6 +219,7 @@ docker.io/hengyunabc/arthas
 docker.io/henrygd/beszel
 docker.io/henrygd/beszel-agent
 docker.io/heroiclabs/nakama-pluginbuilder
+docker.io/hivemq/*
 docker.io/hkalexling/mango
 docker.io/homeassistant/*
 docker.io/hoppscotch/hoppscotch


### PR DESCRIPTION
白名单级别
需要这个组织下的所有镜像 (如 docker.io/hivemq/*)

镜像仓库地址
https://hub.docker.com/r/hivemq/...

这是镜像仓库官方认证过的么?
不是(请补充下面的信息，乱填将关闭申请)

项目源码地址 或 组织地址
https://github.com/hivemq/hivemq-community-edition

官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)
https://www.hivemq.com/

补充说明
HiveMQ
HiveMQ CE is a Java-based open source MQTT broker that fully supports MQTT 3.x and MQTT 5. It is the foundation of the HiveMQ Enterprise Connectivity and Messaging Platform