### PR TITLE
add confluent io docker image supported.

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -103,6 +103,7 @@ docker.io/cloudreve/cloudreve
 docker.io/codercom/code-server
 docker.io/codewisdom/*
 docker.io/collabora/code
+docker.io/confluentinc/*
 docker.io/containrrr/watchtower
 docker.io/continuumio/miniconda3
 docker.io/coredns/*


### PR DESCRIPTION
add confluent platform image supported.

[official web site](https://www.confluent.io/)

[official docker hub web site](https://hub.docker.com/u/confluentinc)

[official github](https://github.com/confluentinc)