### PR TITLE
Update allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -695,6 +695,7 @@ docker.io/stilleshan/frps
 docker.io/stirlingtools/stirling-pdf
 docker.io/streamnative/*
 docker.io/styletang/rocketmq-console-ng
+docker.io/subfuzion/netcat
 docker.io/supabase/*
 docker.io/supermanito/arcadia
 docker.io/superng6/qbittorrentee


### PR DESCRIPTION
it's a sub image used by sentry self-hosted (the most popular software monitor)