### PR TITLE
添加ascentstream到白名单

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -51,6 +51,7 @@ docker.io/arizephoenix/phoenix
 docker.io/arm64v8/*
 docker.io/artalk/artalk-go
 docker.io/ascendai/*
+docker.io/ascentstream/*
 docker.io/atlassian/*
 docker.io/authelia/authelia
 docker.io/automatischio/automatisch


### PR DESCRIPTION
白名单级别
需要这个组织下的所有镜像 (如 docker.io/ascentstream/*)

镜像仓库地址
https://hub.docker.com/r/ascentstream/...

这是镜像仓库官方认证过的么?
不是(请补充下面的信息，乱填将关闭申请)

项目源码地址 或 组织地址
https://github.com/ascentstream

官网 或 文档 或 项目源码 中哪提及对应的镜像的地址 (需要证明这个镜像和源码有实际关联)
https://ascentstream.com/

补充说明
谙流科技(AscentStream)
谙流™云原生消息平台（ASP）是围绕 Apache Pulsar 打造的新一代金融级消息平台