### PR TITLE
added google-samples and alexzhc to allowed list

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1068,3 +1068,6 @@ rocks.canonical.com/**
 us-central1-docker.pkg.dev/keephq/keep/keep-api
 us-central1-docker.pkg.dev/keephq/keep/keep-ui
 us.gcr.io/k8s-artifacts-prod/**
+gcr.io/google-samples/*
+docker.io/alexzhc/*
+


### PR DESCRIPTION
google-samples 里有很多 k8s 官方 yaml example 用到的镜像，例如 gcr.m.daocloud.io/google-samples/xtrabackup:1.0
docker.io/alexzhc 有我做的几个工具镜像例如：autossh 和 vscode