### PR TITLE
feat(allows): add docker.io/hiyouga/pytorch

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -258,6 +258,7 @@ docker.io/henrygd/beszel-agent
 docker.io/heroiclabs/nakama-pluginbuilder
 docker.io/hewenyulucky/*
 docker.io/hivemq/*
+docker.io/hiyouga/pytorch
 docker.io/hkalexling/mango
 docker.io/homeassistant/*
 docker.io/hoppscotch/hoppscotch


### PR DESCRIPTION
添加hiyouga/pytorch的镜像

Fixed #43705
