### PR TITLE
Add Passbolt Docker image to allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -652,9 +652,9 @@ docker.io/p3terx/aria2-pro
 docker.io/p3terx/ariang
 docker.io/paddlepaddle/paddle
 docker.io/paketobuildpacks/*
-docker.io/passbolt/passbolt
 docker.io/pandoc/*
 docker.io/paradedb/*
+docker.io/passbolt/passbolt
 docker.io/pepperlabs/peppermint
 docker.io/percona/*
 docker.io/pgautoupgrade/pgautoupgrade


### PR DESCRIPTION
Fixed https://github.com/DaoCloud/public-image-mirror/issues/44067