### PR TITLE
add sissbruecker/linkding to whitelist

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -762,6 +762,7 @@ docker.io/shieldsio/shields
 docker.io/shingarey/foundationpose_custom_cuda121
 docker.io/sickcodes/docker-osx
 docker.io/silkeh/clang
+docker.io/sissbruecker/linkding
 docker.io/sj26/mailcatcher
 docker.io/slimerl/slime
 docker.io/slskd/slskd


### PR DESCRIPTION
opensource project: https://github.com/sissbruecker/linkding