### PR TITLE
Allow: add docker.io/lihualiu/sam-6d to allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -565,6 +565,7 @@ docker.io/library/yourls
 docker.io/library/znc
 docker.io/library/zookeeper
 docker.io/libretranslate/libretranslate
+docker.io/lihualiu/sam-6d
 docker.io/linkease/ddnsto
 docker.io/linkease/desktop-ubuntu-standard-amd64
 docker.io/linkease/desktop-ubuntu-standard-arm64


### PR DESCRIPTION
Fixed #45200

/auto-cc

## Verification
- Source: https://github.com/JiehongLin/SAM-6D (CVPR2024, 656 ⭐)
- README mentions docker image: hub.docker.com/r/lihualiu/sam-6d