### PR TITLE
Add Wazuh security platform images to allowlist

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1227,3 +1227,4 @@ us-central1-docker.pkg.dev/k8s-staging-images/**
 us-central1-docker.pkg.dev/keephq/keep/keep-api
 us-central1-docker.pkg.dev/keephq/keep/keep-ui
 us.gcr.io/k8s-artifacts-prod/**
+docker.io/wazuh/*


### PR DESCRIPTION
Add wazuh/wazuh-manager, wazuh/wazuh-indexer, wazuh/wazuh-dashboard images to allowlist for security monitoring platform deployment.