### PR TITLE
Allow: add ghcr.io/vllm-project/guidellm to allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1134,6 +1134,7 @@ ghcr.io/tiryoh/ros2-desktop-vnc
 ghcr.io/toeverything/affine-graphql
 ghcr.io/umami-software/umami
 ghcr.io/universaloj/**
+ghcr.io/vllm-project/guidellm
 ghcr.io/wg-easy/wg-easy
 ghcr.io/wzshiming/**
 ghcr.io/ylianst/meshcentral


### PR DESCRIPTION
Fixed #45209

Verification:
- Source: https://github.com/vllm-project/guidellm (923 stars)
- Reason: README explicitly recommends this image (ghcr.io/vllm-project/guidellm)

/auto-cc
