### PR TITLE
Allow: add docker.io/greptime/** to allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -286,6 +286,7 @@ docker.io/graylog/graylog-datanode
 docker.io/greatsql/*
 docker.io/greenbone/*
 docker.io/greper/certd
+docker.io/greptime/*
 docker.io/guacamole/*
 docker.io/guiji2025/*
 docker.io/gztime/gzctf


### PR DESCRIPTION
Fixed #45454

/auto-cc