### PR TITLE
[codex] Add cloudnative-pg to allows

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1005,6 +1005,7 @@ ghcr.io/chaosblade-io/**
 ghcr.io/chroma-core/chroma
 ghcr.io/cinnamon/kotaemon
 ghcr.io/cirruslabs/**
+ghcr.io/cloudnative-pg/**
 ghcr.io/cloudtty/cloudshell
 ghcr.io/coder/**
 ghcr.io/codex-team/codex.docs


### PR DESCRIPTION
## Summary

- Add `ghcr.io/cloudnative-pg/**` to `allows.txt`.
- Keeps the entry in the existing `ghcr.io` sorted section.

Closes #45486.

## Validation

- Confirmed the allow entry appears exactly once.
- Ran `git diff --check`.