### PR TITLE
[codex] Add dataiku dss to allows

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -156,6 +156,7 @@ docker.io/danielqsj/kafka-exporter
 docker.io/daprio/*
 docker.io/darthsim/imgproxy
 docker.io/dataease/sqlbot
+docker.io/dataiku/dss
 docker.io/datastax/*
 docker.io/daytonaio/sandbox
 docker.io/dbeaver/cloudbeaver


### PR DESCRIPTION
## Summary

- Add docker.io/dataiku/dss to allows.txt.
- Keep the entry in the existing docker.io sorted section.

Closes #45510.

## Validation

- Confirmed the allow entry appears exactly once.
- Ran git diff --check.