### PR TITLE
Allow: add lightseekorg/smg to allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -580,6 +580,7 @@ docker.io/library/yourls
 docker.io/library/znc
 docker.io/library/zookeeper
 docker.io/libretranslate/libretranslate
+docker.io/lightseekorg/smg
 docker.io/lihualiu/sam-6d
 docker.io/linkease/ddnsto
 docker.io/linkease/desktop-ubuntu-standard-amd64


### PR DESCRIPTION
Fixed #45674

/auto-cc
