### PR TITLE
Allow: add docker.io/dperson/openvpn-client to allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1272,3 +1272,4 @@ us-central1-docker.pkg.dev/k8s-staging-images/**
 us-central1-docker.pkg.dev/keephq/keep/keep-api
 us-central1-docker.pkg.dev/keephq/keep/keep-ui
 us.gcr.io/k8s-artifacts-prod/**
+docker.io/dperson/openvpn-client


### PR DESCRIPTION
Fixed #45638

/auto-cc