### PR TITLE
Allow: add ghcr.io/volcengine/openviking to allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1272,3 +1272,4 @@ us-central1-docker.pkg.dev/k8s-staging-images/**
 us-central1-docker.pkg.dev/keephq/keep/keep-api
 us-central1-docker.pkg.dev/keephq/keep/keep-ui
 us.gcr.io/k8s-artifacts-prod/**
+ghcr.io/qq85423296/t3fap

--- a/allows.txt
+++ b/allows.txt
@@ -1273,3 +1273,4 @@ us-central1-docker.pkg.dev/keephq/keep/keep-api
 us-central1-docker.pkg.dev/keephq/keep/keep-ui
 us.gcr.io/k8s-artifacts-prod/**
 ghcr.io/qq85423296/t3fap
+ghcr.io/volcengine/openviking


### PR DESCRIPTION
Fixed #45634

- ✅ GitHub star > 10 (25,877)
- ✅ 开源项目 (AGPLv3 license)
- ✅ 官方使用 ghcr.io 托管镜像 (docker-compose.yml)

/auto-cc