### PR TITLE
Allow: add docker.io/dperson/openvpn-client to allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -186,6 +186,7 @@ docker.io/dorowu/ubuntu-desktop-lxde-vnc
 docker.io/dpage/*
 docker.io/dpanel/base-image
 docker.io/dpanel/dpanel
+docker.io/dperson/openvpn-client
 docker.io/dragonflydb/dragonfly
 docker.io/dragonflyoss/client
 docker.io/dragonflyoss/dfdaemon


### PR DESCRIPTION
Fixed #45638

/auto-cc