### PR TITLE
Allow: add docker.io/logvar/danmu-api to allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1272,3 +1272,4 @@ us-central1-docker.pkg.dev/k8s-staging-images/**
 us-central1-docker.pkg.dev/keephq/keep/keep-api
 us-central1-docker.pkg.dev/keephq/keep/keep-ui
 us.gcr.io/k8s-artifacts-prod/**
+ghcr.io/qq85423296/t3fap

--- a/allows.txt
+++ b/allows.txt
@@ -1273,3 +1273,4 @@ us-central1-docker.pkg.dev/keephq/keep/keep-api
 us-central1-docker.pkg.dev/keephq/keep/keep-ui
 us.gcr.io/k8s-artifacts-prod/**
 ghcr.io/qq85423296/t3fap
+docker.io/logvar/danmu-api


### PR DESCRIPTION
Fixed #45673

/auto-cc