### PR TITLE
Allow: add lightseekorg/smg, logvar/danmu-api, haroldli/alist-tvbox, fish2018/pansou, supersonicbi/supersonic, wei-shaw/sub2api, unsloth/unsloth, volcengine/openviking to allows.txt

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1272,3 +1272,4 @@ us-central1-docker.pkg.dev/k8s-staging-images/**
 us-central1-docker.pkg.dev/keephq/keep/keep-api
 us-central1-docker.pkg.dev/keephq/keep/keep-ui
 us.gcr.io/k8s-artifacts-prod/**
+ghcr.io/qq85423296/t3fap

--- a/allows.txt
+++ b/allows.txt
@@ -1274,3 +1274,11 @@ us-central1-docker.pkg.dev/keephq/keep/keep-api
 us-central1-docker.pkg.dev/keephq/keep/keep-ui
 us.gcr.io/k8s-artifacts-prod/**
 ghcr.io/qq85423296/t3fap
+docker.io/lightseekorg/smg
+docker.io/logvar/danmu-api
+docker.io/haroldli/alist-tvbox
+ghcr.io/fish2018/pansou
+docker.io/supersonicbi/supersonic
+ghcr.io/wei-shaw/sub2api
+docker.io/unsloth/unsloth
+ghcr.io/volcengine/openviking


### PR DESCRIPTION
Fixed #45674
Fixed #45673
Fixed #45671
Fixed #45667
Fixed #45660
Fixed #45658
Fixed #45642
Fixed #45634

/auto-cc