### PR TITLE
add run-ai images

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1166,6 +1166,7 @@ ghcr.io/puppeteer/puppeteer
 ghcr.io/rails/**
 ghcr.io/rancher/**
 ghcr.io/rjmalagon/ollama-linux-amd-apu
+ghcr.io/run-ai/**
 ghcr.io/seriousm4x/upsnap
 ghcr.io/shipwright-io/**
 ghcr.io/siderolabs/*


### PR DESCRIPTION
Supplement the run-ai series related images   
so that you can quickly pull device-plugin, kwok-gpu-device-plugin and other images.