### PR TITLE
add ghcr.io/openai/** to allows

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1152,6 +1152,7 @@ ghcr.io/nousresearch/*
 ghcr.io/nvidia/**
 ghcr.io/open-telemetry/**
 ghcr.io/open-webui/**
+ghcr.io/openai/**
 ghcr.io/opencidn/**
 ghcr.io/openclaw/openclaw
 ghcr.io/openfaas/**


### PR DESCRIPTION
## 白名单级别

只需要这一个镜像 / 需要这个组织下所有镜像

## 镜像仓库地址

ghcr.io/openai/**

## 是否 Verified Publisher / Sponsored OSS / Official Image

不是

## 项目源码地址

https://github.com/openai

## 镜像关联证明

OpenAI 官方发布的 Docker 镜像，如 openai-python 等项目在 GitHub 上有官方维护的容器镜像。

## 补充说明

OpenAI 是知名 AI 公司，其开源项目如 openai-python 有 31.3k stars，符合白名单审批标准。