### PR TITLE
Allow: docker.io/mariadb/maxscale #45857

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -629,6 +629,7 @@ docker.io/mailserver/*
 docker.io/manjarolinux/*
 docker.io/manticoresearch/manticore
 docker.io/maptiler/*
+docker.io/mariadb/maxscale
 docker.io/martialblog/limesurvey
 docker.io/mattermost/focalboard
 docker.io/mattermost/mattermost-team-edition


### PR DESCRIPTION
Fixed #45857