### PR TITLE
feat: allow GCWing BitFun Relay Server image

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1070,6 +1070,7 @@ ghcr.io/flannel-io/*
 ghcr.io/flexget/flexget
 ghcr.io/fluent/fluent-operator/*
 ghcr.io/freecodecamp/devdocs
+ghcr.io/gcwing/bitfun-relay-server
 ghcr.io/gethomepage/homepage
 ghcr.io/getsentry/*
 ghcr.io/ggerganov/llama.cpp


### PR DESCRIPTION
Fixed #45885

Allow the public, MIT-licensed Relay Server image published by the GCWing/BitFun source repository:

- Image: `ghcr.io/gcwing/bitfun-relay-server`
- Source: https://github.com/GCWing/BitFun
- Image/deploy implementation: https://github.com/GCWing/BitFun/pull/2013
- Package: https://github.com/GCWing/BitFun/pkgs/container/bitfun-relay-server

The image is built by GitHub Actions from the matching signed release artifacts and publishes a single multi-platform manifest for linux/amd64 and linux/arm64.