### PR TITLE
Allow: docker.io/sigoden/dufs #45895

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -850,6 +850,7 @@ docker.io/serversideup/*
 docker.io/shieldsio/shields
 docker.io/shingarey/foundationpose_custom_cuda121
 docker.io/sickcodes/docker-osx
+docker.io/sigoden/dufs
 docker.io/silkeh/clang
 docker.io/simonrupf/chronyd
 docker.io/sinamics/ztnet


### PR DESCRIPTION
Fixed #45895