### PR TITLE
Add pgsty/silo to allowed Docker images

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -761,6 +761,7 @@ docker.io/percona/*
 docker.io/pgautoupgrade/pgautoupgrade
 docker.io/pgrouting/pgrouting
 docker.io/pgsty/minio
+docker.io/pgsty/silo
 docker.io/pgvector/pgvector
 docker.io/photoprism/photoprism
 docker.io/phpmyadmin/*


### PR DESCRIPTION
原镜像：docker.io/pgsty/minio
现已更名为silo，故需要同步调整为pgsty/silo

Fixes #45955
