### PR TITLE
Add ghcr.io/scaleapi/drugdiscoverybench

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1188,6 +1188,7 @@ ghcr.io/rails/**
 ghcr.io/rancher/**
 ghcr.io/rjmalagon/ollama-linux-amd-apu
 ghcr.io/run-ai/**
+ghcr.io/scaleapi/drugdiscoverybench
 ghcr.io/seriousm4x/upsnap
 ghcr.io/shipwright-io/**
 ghcr.io/siderolabs/*


### PR DESCRIPTION
Please add ghcr.io/scaleapi/drugdiscoverybench (Scale AI's public DrugDiscoveryBench evaluation image, ~6 GB). Pulling it directly from ghcr.io is not feasible from our network. Thanks!