### PR TITLE
Add ai-dynamo to allowed container images

### DIFF
--- a/allows.txt
+++ b/allows.txt
@@ -1010,6 +1010,7 @@ ghcr.io/abhigyanpatwari/gitnexus-web
 ghcr.io/actions/**
 ghcr.io/advplyr/audiobookshelf
 ghcr.io/agent-infra/**
+ghcr.io/ai-dynamo/**
 ghcr.io/ajnart/homarr
 ghcr.io/amamba-io/**
 ghcr.io/analogj/scrutiny


### PR DESCRIPTION
Fixes https://github.com/DaoCloud/public-image-mirror/issues/45961